### PR TITLE
docfx changes to support new moniker for extension content

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -8,6 +8,7 @@
           "**/*.yml"
         ],
         "src": "docs-ref-autogen",
+        "version": "azdevops-ext-latest",
         "exclude": [
           "**/obj/**",
           "**/includes/**",
@@ -43,6 +44,11 @@
     ],
     "overwrite": [],
     "externalReference": [],
+    "versions": {
+      "azdevops-ext-latest": {
+        "dest": "latest"
+      }
+    },
     "globalMetadata": {
       "breadcrumb_path": "~/breadcrumb/toc.yml"
     },


### PR DESCRIPTION
We have to have monikers to support versioning for APIs. This PR is set up to connect a prelease moniker to the content.