### PR TITLE
Add apiplatform metadata

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -50,7 +50,8 @@
       }
     },
     "globalMetadata": {
-      "breadcrumb_path": "~/breadcrumb/toc.yml"
+      "breadcrumb_path": "~/breadcrumb/toc.yml",
+      "apiPlatform": "javascript"
     },
     "fileMetadata": {},
     "template": [],


### PR DESCRIPTION
Ensuring that the JavaScript API information tag is flagged for the API browser.